### PR TITLE
Fix several bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ As a general advice refrain from using superuser accounts like hdfs, hadaoop.
 * Through melpa:
 Ensure you have melpa in your package-archives
 (see [Melpa Installation](http://melpa.org/#/getting-started)).
-Then, M-x package-install [RET] tramp-hdfs. 
+Then, M-x package-install [RET] tramp-hdfs.
 
 ## Run inside docker
 ```bash
@@ -40,6 +40,9 @@ docker run -it --rm -v `pwd`:/root/.emacs.d silex/emacs
 ```
 
 ## Run tests
+* Test assume a running HDFS instance at host "node-1".  You will need
+to map this name to your actual instance via /etc/hosts or some other
+mechanism.
 ```bash
 docker run -it --rm -v `pwd`:/root/.emacs.d silex/emacs --batch -l ert -l /root/.emacs.d/tramp-hdfs.el -l /root/.emacs.d/tramp-hdfs-tests.el -f ert-run-tests-batch-and-exit
 ```

--- a/tramp-hdfs-tests.el
+++ b/tramp-hdfs-tests.el
@@ -14,13 +14,15 @@
 
 ;;; Commentary:
 ;; These are some tests for tramp-hdfs.
+;; "node-1" should be mapped to running HDFS instance via /etc/hosts.
+;;
 ;;
 ;;; Code:
 (require 'tramp-hdfs)
 (require 'ert)
 (ert-deftest hdfs-test-expand-file-name1 ()
   "Tests the expand-file-name for hdfs."
-  (should (equal (expand-file-name "/hdfs:node-1:"             "/tmp") "/hdfs:root@node-1:/"))
+  (should (equal (expand-file-name "/hdfs:node-1:"             "/tmp") (format "/hdfs:%s@node-1:/" (user-login-name))))
   (should (equal (expand-file-name "/hdfs:root@node-1:"        "/Users") "/hdfs:root@node-1:/" ))
   (should (equal (expand-file-name "/hdfs:root@node-1:"        nil)      "/hdfs:root@node-1:/" ))
   (should (equal (expand-file-name "/hdfs:root@node-1:/"       "/Users") "/hdfs:root@node-1:/" ))

--- a/tramp-hdfs-tests.el
+++ b/tramp-hdfs-tests.el
@@ -14,8 +14,6 @@
 
 ;;; Commentary:
 ;; These are some tests for tramp-hdfs.
-;; "node-1" should be mapped to running HDFS instance via /etc/hosts.
-;;
 ;;
 ;;; Code:
 (require 'tramp-hdfs)

--- a/tramp-hdfs.el
+++ b/tramp-hdfs.el
@@ -504,8 +504,8 @@ These are all file names in directory DIRECTORY which begin with FILE."
   (with-parsed-tramp-file-name directory nil
     ;; We must also flush the cache of the directory, because
     ;; `file-attributes' reads the values from there.
-    (tramp-flush-file-property v (file-name-directory localname))
-    (tramp-flush-directory-property v localname)
+    (tramp-flush-file-properties v (file-name-directory localname))
+    (tramp-flush-directory-properties v localname)
     (let ((url (tramp-hdfs-create-url
 		localname
 		hdfs-delete-op
@@ -520,8 +520,8 @@ These are all file names in directory DIRECTORY which begin with FILE."
     (with-parsed-tramp-file-name filename nil
       ;; We must also flush the cache of the directory, because
       ;; `file-attributes' reads the values from there.
-      (tramp-flush-file-property v (file-name-directory localname))
-      (tramp-flush-file-property v localname)
+      (tramp-flush-file-properties v (file-name-directory localname))
+      (tramp-flush-file-properties v localname)
       (let ((url (tramp-hdfs-create-url
 		localname
 		hdfs-delete-op

--- a/tramp-hdfs.el
+++ b/tramp-hdfs.el
@@ -132,7 +132,7 @@
     (file-notify-add-watch . tramp-handle-file-notify-add-watch)
     (file-notify-rm-watch . tramp-handle-file-notify-rm-watch)
     (file-ownership-preserved-p . ignore)
-    (file-readable-p . tramp-hdfs-handle-file-readable-p)
+    (file-readable-p . tramp-handle-file-exists-p)
     (file-regular-p . tramp-handle-file-regular-p)
     (file-remote-p . tramp-handle-file-remote-p)
     ;; `file-selinux-context' performed by default handler.
@@ -156,7 +156,7 @@
     (set-visited-file-modtime . tramp-handle-set-visited-file-modtime)
     (shell-command . ignore)
     (start-file-process . ignore)
-    (unhandled-file-name-directory . tramp-handle-unhandled-file-name-directory)
+    (unhandled-file-name-directory . ignore)
     (vc-registered . ignore)
     (verify-visited-file-modtime . tramp-handle-verify-visited-file-modtime)
     (write-region . ignore))
@@ -170,15 +170,6 @@ Operations not mentioned here will be handled by the default Emacs primitives.")
   "Check if it's a FILENAME for hdfs servers."
   (string= (tramp-file-name-method (tramp-dissect-file-name filename))
 	   tramp-hdfs-method))
-
-(defun tramp-hdfs-handle-file-readable-p (filename)
-  "Like `file-readable-p' for Tramp files."
-  (with-parsed-tramp-file-name filename nil
-    (with-tramp-file-property v localname "file-readable-p"
-      ;; Examine `file-attributes' cache to see if request can be
-      ;; satisfied without remote operation.
-      ;;TODO we need to do actual check using rest calls
-      (tramp-check-cached-permissions v ?r))))
 
 
 ;;;###tramp-autoload
@@ -237,11 +228,11 @@ Optional argument ARGS is a list of arguments to pass to the OPERATION."
   (let ((response
 	 (if tramp-hdfs-curl-path
 	     (progn
-	       (tramp-message vec 10 "Command: %s -k -sSL --negotiate -u : -X %s %s" tramp-hdfs-curl-path method url)
+	       (tramp-message vec 10 "Command: %s -k -sSL -X %s %s" tramp-hdfs-curl-path method url)
 	       (string-trim (with-output-to-string
 			      (with-current-buffer
 				  standard-output
-				(call-process tramp-hdfs-curl-path nil t nil "-k" "-sSL" "--negotiate" "-u" ":"  "-X" method url)))))
+				(call-process tramp-hdfs-curl-path nil t nil "-k" "-sSL" "-X" method url)))))
 	   (let* ((url-request-method method)
 		  (url-http-attempt-keepalives nil)
 		  (buff (url-retrieve-synchronously url))
@@ -305,11 +296,10 @@ Optional argument DIR The directory to use for expansion. If nil use present wor
       (let ((directory-sep-char ?/)
 	    (default-directory (tramp-compat-temporary-file-directory)))
 	(tramp-make-tramp-file-name
-	 method user host
+         v
 	 (tramp-drop-volume-letter
 	  (tramp-run-real-handler
-	   'expand-file-name (list localname)))
-	 hop)))))
+	   'expand-file-name (list localname))))))))
 
 (defun tramp-hdfs-handle-file-attributes (filename &optional id-format)
   "Like `file-attributes' for Tramp files.
@@ -348,7 +338,7 @@ Optional argument SUFFIX extra arguments to be appended to url."
     (setq path (concat "/" path)))
   (let ((url (concat
 	      ;;http://node-1:57000/webhdfs/v1
-	      (format "%s://%s:%s%s" webhdfs-protocol (tramp-file-name-real-host v) (or (tramp-file-name-port v) (number-to-string webhdfs-port)) webhdfs-endpoint)
+	      (format "%s://%s:%s%s" webhdfs-protocol (tramp-file-name-host v) (or (tramp-file-name-port v) (number-to-string webhdfs-port)) webhdfs-endpoint)
 	      ;;/tmp?user.name=root&op=OPEN
 	      (format "%s?user.name=%s&op=%s"  path (tramp-file-name-user v) op)
 	      (when suffix "&") suffix)))
@@ -411,7 +401,6 @@ FILENAME the filename to be copied locally."
        v 'file-error
        "Cannot make local copy of non-existing file `%s'" filename))
     (let* ((size (nth 7 (file-attributes (file-truename filename))))
-	   (localname (tramp-hdfs-get-filename v))
 	   (url-size-params (tramp-hdfs-get-size-params size))
 	   (url (tramp-hdfs-create-url localname hdfs-open-op v url-size-params))
 	   (content (tramp-hdfs-get-url-content url v))
@@ -465,16 +454,16 @@ These are all file names in directory DIRECTORY which begin with FILE."
      (or size "0") ; size
      (format-time-string
       (if (time-less-p
-	   (time-subtract (current-time) mtime)
-	   tramp-half-a-year)
+           ;; Half a year
+	   (time-since mtime) (days-to-time 183))
 	  "%b %e %R"
-	"%b %e  %Y")
+	"%b %e %Y")
       mtime)
      filename)))
 
 (defun tramp-hdfs-list-directory (v)
   "List files of a hdfs dir."
-  (let* ((url (tramp-hdfs-create-url (tramp-hdfs-get-filename v) hdfs-list-op v))
+  (let* ((url (tramp-hdfs-create-url (tramp-file-name-localname v) hdfs-list-op v))
 	 (retval (tramp-hdfs-json-to-lisp (tramp-hdfs-get-url-content url v) v)))
     (cdadar retval)))
 
@@ -503,7 +492,7 @@ These are all file names in directory DIRECTORY which begin with FILE."
     (tramp-flush-file-property v (file-name-directory localname))
     (tramp-flush-directory-property v localname)
     (let ((url (tramp-hdfs-create-url
-		(tramp-hdfs-get-filename v)
+		localname
 		hdfs-delete-op
 		v
 		(if recursive "recursive=true" "recursive=false"))))
@@ -519,16 +508,11 @@ These are all file names in directory DIRECTORY which begin with FILE."
       (tramp-flush-file-property v (file-name-directory localname))
       (tramp-flush-file-property v localname)
       (let ((url (tramp-hdfs-create-url
-		(tramp-hdfs-get-filename v)
+		localname
 		hdfs-delete-op
 		v
 		"recursive=false")))
 	(tramp-hdfs-json-to-lisp (tramp-hdfs-delete-url url v) v)))))
-
-;; Internal file name functions.
-(defun tramp-hdfs-get-filename (vec)
-  "Returns the file name of vec."
-  (elt vec 3))
 
 (add-hook 'tramp-unload-hook
 	  (lambda ()


### PR DESCRIPTION
* tramp-hdfs-tests.el (hdfs-test-expand-file-name1): Don't assume root
as default user.
* tramp-hdfs.el (tramp-hdfs-file-name-handler-alist): file-readable-p
enters infinite loop, unhandled-file-name-directory refers to
non-existing function.
(tramp-hdfs-handle-file-readable-p): Remove.
(tramp-hdfs-do-rest-call): Remove "--negotiate" (SPNEGO) and "-u :".
(tramp-hdfs-handle-expand-file-name): Fix invocation of
tramp-make-tramp-file-name.
(tramp-hdfs-create-url): Fix invocation of tramp-file-name-host.
(tramp-hdfs-create-one-line): Replace non-existing tramp-half-a-year.
(tramp-hdfs-get-filename): Remove.
(tramp-hdfs-handle-file-local-copy, tramp-hdfs-list-directory)
(tramp-hdfs-handle-delete-directory, tramp-hdfs-handle-delete-file):
Remove its usages.